### PR TITLE
Handle driver api errors

### DIFF
--- a/avi_lbaasv2/avi_ocdriver.py
+++ b/avi_lbaasv2/avi_ocdriver.py
@@ -269,7 +269,7 @@ class OpencontrailAviLoadbalancerDriver(
     @cc_trace
     def delete_loadbalancer(self, loadbalancer):
         lb = transform_loadbalancer_obj(self, loadbalancer['id'], loadbalancer)
-        delete_vsvip(lb, self.client)
+        delete_vsvip(lb, self.client, contrail_lb=loadbalancer)
 
     @cc_trace
     def create_listener(self, listener):

--- a/avi_lbaasv2/avi_ocdriver.py
+++ b/avi_lbaasv2/avi_ocdriver.py
@@ -269,6 +269,9 @@ class OpencontrailAviLoadbalancerDriver(
     @cc_trace
     def delete_loadbalancer(self, loadbalancer):
         lb = transform_loadbalancer_obj(self, loadbalancer['id'], loadbalancer)
+        if not lb:
+            self.log.warn("LB object not found in config DB")
+
         delete_vsvip(lb, self.client, contrail_lb=loadbalancer)
 
     @cc_trace

--- a/avi_lbaasv2/avi_ocdriver.py
+++ b/avi_lbaasv2/avi_ocdriver.py
@@ -47,8 +47,11 @@ def cc_trace(f):
             res = f(self, *args, **kwargs)
             return res
         except Exception as e:
-            self.log.exception('ocavi %s', e)
-            raise e
+            self.log.exception('ocavi fn %s failed %s', f.__name__, e)
+            # Don't raise error - this might cause contrail-svc-monitor
+            # to crash
+            # raise e
+
     return f_trace
 
 
@@ -375,19 +378,17 @@ class OpencontrailAviLoadbalancerDriver(
     def delete_health_monitor(self, health_monitor, pool_id):
         self.delete_pool_health_monitor(health_monitor, pool_id)
 
+    @cc_trace
     def update_health_monitor3x(self, id, health_monitor):
         hm = transform_hm_obj(self, id, health_monitor)
         hm_update_avi_hm(self, None, hm)
 
+    @cc_trace
     def set_config_v2(self, lb_id):
-        try:
-            vmi_id = LoadbalancerSM.get(lb_id).virtual_machine_interface
-            vmi = VirtualMachineInterfaceSM.get(vmi_id)
-            fips = vmi.floating_ips
-            return str(fips)
-        except Exception as e:
-            self.log.exception("set_config_v2 failed: %s", e)
-            pass
+        vmi_id = LoadbalancerSM.get(lb_id).virtual_machine_interface
+        vmi = VirtualMachineInterfaceSM.get(vmi_id)
+        fips = vmi.floating_ips
+        return str(fips)
 
     # ignored APIs ###
 

--- a/avi_lbaasv2/common/avi_generic.py
+++ b/avi_lbaasv2/common/avi_generic.py
@@ -358,10 +358,21 @@ def update_vsvip(os_lb, avi_client, avi_tenant_uuid, cloud, vsvip=None,
     return res
 
 
-def delete_vsvip(os_lb, avi_client):
-    vsvip_uuid = form_vsvip_uuid(os_lb.id)
-    avi_tenant_uuid = os2avi_uuid("tenant", os_lb.tenant_id)
-    avi_client.delete("vsvip", vsvip_uuid, avi_tenant_uuid)
+def delete_vsvip(os_lb, avi_client, contrail_lb=None):
+    vsvip_uuid = None
+    avi_tenant_uuid = None
+    if os_lb:
+        vsvip_uuid = form_vsvip_uuid(os_lb.id)
+        avi_tenant_uuid = os2avi_uuid("tenant", os_lb.tenant_id)
+    elif contrail_lb:
+        lb_id = contrail_lb.get('id', None)
+        tenant_id = contrail_lb.get('tenant_id', None)
+        if lb_id and tenant_id:
+            vsvip_uuid = form_vsvip_uuid(lb_id)
+            avi_tenant_uuid = os2avi_uuid("tenant", tenant_id)
+
+    if vsvip_uuid and avi_tenant_uuid:
+        avi_client.delete("vsvip", vsvip_uuid, avi_tenant_uuid)
 
 
 def get_vrf_context(subnet_uuid, cloud, avi_tenant_uuid, avi_client,


### PR DESCRIPTION
1. Don't raise exceptions from Contrail Driver methods
Don't raise exception/errors in the Contrail Driver implementation
methods for LBaaSv2 APIs. Raising an exception/error is causing
contrail-svc-monitor process to crash.
2. Handle not-found error in delete LB
In Contrail Driver, when delete loadbalancer is invoked, we are checking
the LB object in Cotrail Config DB. Because of asynchronous method of
API handling in Contrail, object from config DB is sometimes deleted
even before Driver can handle the method. The Driver will then fail to
fetch the object from DB and get into null-pointer kind of error.
Handle this error by relying on the data passed to the driver if the
driver cannot find the object in DB. The data passed to driver has a
copy of LB details that can be used to delete the objects from Avi.